### PR TITLE
Override binary names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ text = <%= helper.get_text %>
 
 The assets might not get recompiled, even if they have to, as this gem only checks if the asset file has changed (which is probably the only safe/fast way to do this).
 
+### `diff` and `cp` behaviour
+
+Both `diff` and `cp` used by this gem expect certain behaviour and break if you use a tool that doesn't provide those behaviours. These have both been observed on
+SmartOS, where `gdiff` and `gcp` provide the behaviour required, but the built in `diff` and `cp` don't.
+
+If you're running into errors with diff, make sure you're using a diff binary that supports the `-Nqr` arguments. If not, you can point this gem at the correct diff binary  
+to use on your nodes by setting the `:faster_assets_diff` variable in your deploy config:
+
+    set :faster_assets_diff, :gdiff
+
+`cp` on the other hand, expects `cp -r` to preserve symlinks. If your cp binary doesn't, then you can point at a binary that does by setting `:faster_assets_cp` in your
+deploy config:
+
+    set :faster_assets_cp, :gcp
+
 ### More Capistrano automation?
 
 If you'd like to streamline your Capistrano deploys, you might want to check

--- a/lib/capistrano/faster_assets.rb
+++ b/lib/capistrano/faster_assets.rb
@@ -1,1 +1,3 @@
 load File.expand_path("../tasks/faster_assets.rake", __FILE__)
+
+set_if_empty :faster_assets_diff, :diff

--- a/lib/capistrano/faster_assets.rb
+++ b/lib/capistrano/faster_assets.rb
@@ -1,3 +1,4 @@
 load File.expand_path("../tasks/faster_assets.rake", __FILE__)
 
 set_if_empty :faster_assets_diff, :diff
+set_if_empty :faster_assets_cp, :cp

--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -36,7 +36,7 @@ namespace :deploy do
 		next if [release, latest].map{|d| test "[ -e #{d} ]"}.uniq == [false]
 		
                 # execute raises if there is a diff
-                execute(:diff, '-Nqr', release, latest) rescue raise(PrecompileRequired)
+                execute(fetch(:faster_assets_diff), '-Nqr', release, latest) rescue raise(PrecompileRequired)
               end
 
               info("Skipping asset precompile, no asset diff found")

--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -42,7 +42,7 @@ namespace :deploy do
               info("Skipping asset precompile, no asset diff found")
 
               # copy over all of the assets from the last release
-              execute(:cp, '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
+              execute(fetch(:faster_assets_cp), '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
             rescue PrecompileRequired
               execute(:rake, "assets:precompile")
             end


### PR DESCRIPTION
A couple of binaries that are called within the precompile check task can behave differently on non-linux OSes and this PR aims to support those OSes by adding the ability to override the binary names.

On SmartOS `gdiff` and `gcp` provide the behaviour required, but the built in `diff` and `cp` don't. (`diff` doesn't support `-N` and `cp -r` doesn't preserve symlinks.)

So to use `gdiff` and `gcp`, my deploy.rb gets the following added:

```
set :faster_assets_diff, :gdiff
set :faster_assets_cp, :gcp
```

And it all works fine.

Out the box those two variables default to `:diff` and `:cp` so it continues to work as before if you don't override them explicitly.
